### PR TITLE
Swipe fix

### DIFF
--- a/app/src/main/java/brnunes/swipeablecardview/SwipeableRecyclerViewTouchListener.java
+++ b/app/src/main/java/brnunes/swipeablecardview/SwipeableRecyclerViewTouchListener.java
@@ -233,6 +233,7 @@ public class SwipeableRecyclerViewTouchListener implements RecyclerView.OnItemTo
                     final View downView = mDownView; // mDownView gets null'd before animation ends
                     final int downPosition = mDownPosition;
                     ++mDismissAnimationRefCount;
+                    setEnabled(false);
                     mDownView.animate()
                             .translationX(dismissRight ? mViewWidth : -mViewWidth)
                             .alpha(0)
@@ -338,6 +339,7 @@ public class SwipeableRecyclerViewTouchListener implements RecyclerView.OnItemTo
                     mRecyclerView.dispatchTouchEvent(cancelEvent);
 
                     mPendingDismisses.clear();
+                    setEnabled(true);
                 }
             }
         });

--- a/app/src/main/java/brnunes/swipeablecardview/SwipeableRecyclerViewTouchListener.java
+++ b/app/src/main/java/brnunes/swipeablecardview/SwipeableRecyclerViewTouchListener.java
@@ -76,6 +76,7 @@ public class SwipeableRecyclerViewTouchListener implements RecyclerView.OnItemTo
     // Transient properties
     private List<PendingDismissData> mPendingDismisses = new ArrayList<>();
     private int mDismissAnimationRefCount = 0;
+    private float mAlpha;
     private float mDownX;
     private float mDownY;
     private boolean mSwiping;
@@ -168,6 +169,7 @@ public class SwipeableRecyclerViewTouchListener implements RecyclerView.OnItemTo
                 }
 
                 if (mDownView != null) {
+                    mAlpha = mDownView.getAlpha();
                     mDownX = motionEvent.getRawX();
                     mDownY = motionEvent.getRawY();
                     mDownPosition = mRecyclerView.getChildPosition(mDownView);
@@ -190,7 +192,7 @@ public class SwipeableRecyclerViewTouchListener implements RecyclerView.OnItemTo
                     // cancel
                     mDownView.animate()
                             .translationX(0)
-                            .alpha(1)
+                            .alpha(mAlpha)
                             .setDuration(mAnimationTime)
                             .setListener(null);
                 }
@@ -245,7 +247,7 @@ public class SwipeableRecyclerViewTouchListener implements RecyclerView.OnItemTo
                     // cancel
                     mDownView.animate()
                             .translationX(0)
-                            .alpha(1)
+                            .alpha(mAlpha)
                             .setDuration(mAnimationTime)
                             .setListener(null);
                 }
@@ -274,8 +276,8 @@ public class SwipeableRecyclerViewTouchListener implements RecyclerView.OnItemTo
 
                 if (mSwiping) {
                     mDownView.setTranslationX(deltaX - mSwipingSlop);
-                    mDownView.setAlpha(Math.max(0f, Math.min(1f,
-                            1f - Math.abs(deltaX) / mViewWidth)));
+                    mDownView.setAlpha(Math.max(0f, Math.min(mAlpha,
+                            mAlpha * (1f - Math.abs(deltaX) / mViewWidth))));
                     return true;
                 }
                 break;
@@ -322,7 +324,7 @@ public class SwipeableRecyclerViewTouchListener implements RecyclerView.OnItemTo
                     ViewGroup.LayoutParams lp;
                     for (PendingDismissData pendingDismiss : mPendingDismisses) {
                         // Reset view presentation
-                        pendingDismiss.view.setAlpha(1f);
+                        pendingDismiss.view.setAlpha(mAlpha);
                         pendingDismiss.view.setTranslationX(0);
                         lp = pendingDismiss.view.getLayoutParams();
                         lp.height = originalHeight;


### PR DESCRIPTION
Fling left, then immediately fling right on an item while the dismiss animation is going on. This will corrupt the state of the recycler view. This proposed fix disables touch right before animation begins, and re-enables it when animation completes.
