### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Sample project implementation of a list of `CardView`s in a `RecyclerView` with 
 
 ![Output sample](https://raw.githubusercontent.com/brnunes/SwipeableRecyclerView/master/demo.gif)
 
-####How to use
+#### How to use
 
 - Add these Gradle dependencies to your app's module:
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
